### PR TITLE
Missing `limit` argument in `dag_paths()` (#65)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggdag (development version)
 
+* Added the `limit` argument to `dag_paths`, `ggdag_paths`, and `ggdag_paths_fan` (see `dagitty::paths`) (#65).
+
 # ggdag 0.2.4
 * `tidy_dagitty()` no longer allows the dendogram layout type (#62)
 * `scale_adjusted()` now correctly aligns legend types (#61)

--- a/R/paths.R
+++ b/R/paths.R
@@ -4,6 +4,7 @@
 #' `ggdag_paths` and `ggdag_paths_fan` plot all open paths. See
 #' [dagitty::paths()] for details.
 #'
+#' @inheritParams dagitty::paths
 #' @param .dag,.tdy_dag input graph, an object of class `tidy_dagitty` or
 #'   `dagitty`
 #' @param from character vector of length 1, name of exposure variable. Default
@@ -12,10 +13,6 @@
 #'   `NULL`, in which case it will check the input DAG for exposure.
 #' @param adjust_for character vector, a set of variables to control for.
 #'   Default is `NULL`.
-#' @param limit numeric value. The maximum number of paths to consider when
-#'   identifying open paths. If `limit` is smaller than the number of paths
-#'   between `from` and `to`, potential open pathways may not be returned.
-#'   However, if `limit` is set too large, you may run into memory issues.
 #' @param directed logical. Should only directed paths be shown?
 #' @param paths_only logical. Should only open paths be returned? Default is
 #'   `FALSE`, which includes every variable and edge in the DAG regardless
@@ -36,29 +33,8 @@
 #'   Default is `NULL`.
 #' @param spread the width of the fan spread
 #'
-#' @return
-#' \describe{
-#'   \item{`dag_paths`}{A `tidy_dagitty` object with the following additional
-#'   columns in the `data` element:
-#'   \describe{
-#'     \item{`set`}{A character vector representing an id for the identified
-#'     open path.}
-#'     \item{`path`}{A character vector with value `"open path"` if the
-#'     corresponding node is on the identified open path and value `NA` if the
-#'     corresponding node is not on the identified open path.
-#'     If `paths_only` is set to `TRUE` all rows where `path` is `NA` are
-#'     removed.}
-#'   }
-#'   The returned `tidy_dagitty` object duplicates for each identified open path
-#'   all node rows in the `data` element and labels for each identified open
-#'   path (as indicated by column `set`) which nodes of the graph are on the
-#'   path (as indicated by column `path`).
-#'   }
-#'   \item{`ggdag_paths`}{A `ggplot` object with a facet for each identified
-#'   open path.}
-#'   \item{`ggdag_paths_fan`}{A `ggplot` object with the same contents as
-#'   with `ggdag_paths`, but identified open paths are plotted in one panel.}
-#' }
+#' @return a `tidy_dagitty` with a `path` column for path variables and a `set`
+#'   grouping column or a `ggplot`.
 #'
 #' @examples
 #' confounder_triangle(x_y_associated = TRUE) %>%

--- a/man/geom_dag_text.Rd
+++ b/man/geom_dag_text.Rd
@@ -66,8 +66,7 @@ Cannot be jointly specified with \code{position}.}
 \item{check_overlap}{If \code{TRUE}, text that overlaps previous text in the
 same layer will not be plotted. \code{check_overlap} happens at draw time and in
 the order of the data. Therefore data should be arranged by the label
-column before calling \code{geom_text()}. Note that this argument is not
-supported by \code{geom_label()}.}
+column before calling \code{geom_label()} or \code{geom_text()}.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -5,13 +5,14 @@
 \alias{dag_paths}
 \alias{ggdag_paths}
 \alias{ggdag_paths_fan}
-\title{Find Pathways Between Variables}
+\title{Find Open Paths Between Variables}
 \usage{
 dag_paths(
   .dag,
   from = NULL,
   to = NULL,
   adjust_for = NULL,
+  limit = 100,
   directed = FALSE,
   paths_only = FALSE,
   ...
@@ -22,6 +23,7 @@ ggdag_paths(
   from = NULL,
   to = NULL,
   adjust_for = NULL,
+  limit = 100,
   directed = FALSE,
   shadow = FALSE,
   ...,
@@ -41,6 +43,7 @@ ggdag_paths_fan(
   from = NULL,
   to = NULL,
   adjust_for = NULL,
+  limit = 100,
   directed = FALSE,
   ...,
   shadow = FALSE,
@@ -69,6 +72,11 @@ is \code{NULL}, in which case it will check the input DAG for exposure.}
 \item{adjust_for}{character vector, a set of variables to control for.
 Default is \code{NULL}.}
 
+\item{limit}{numeric value. The maximum number of paths to consider when
+identifying open paths. If \code{limit} is smaller than the number of paths
+between \code{from} and \code{to}, potential open pathways may not be returned.
+However, if \code{limit} is set too large, you may run into memory issues.}
+
 \item{directed}{logical. Should only directed paths be shown?}
 
 \item{paths_only}{logical. Should only open paths be returned? Default is
@@ -77,8 +85,8 @@ if they are part of the path.}
 
 \item{...}{additional arguments passed to \code{tidy_dagitty()}}
 
-\item{shadow}{logical. Show edges not in path? Ignored if \code{paths_only} is
-\code{TRUE}}
+\item{shadow}{logical. Show edges which are not on an open path? Ignored if
+\code{paths_only} is \code{TRUE}.}
 
 \item{node_size}{size of DAG node}
 
@@ -103,14 +111,38 @@ Default is \code{NULL}.}
 \item{spread}{the width of the fan spread}
 }
 \value{
-a \code{tidy_dagitty} with a \code{path} column for path variables
-and a \code{set} grouping column or a \code{ggplot}
+\describe{
+\item{\code{dag_paths}}{A \code{tidy_dagitty} object with the following additional
+columns in the \code{data} element:
+\describe{
+\item{\code{set}}{A character vector representing an id for the identified
+open path.}
+\item{\code{path}}{A character vector with value \code{"open path"} if the
+corresponding node is on the identified open path and value \code{NA} if the
+corresponding node is not on the identified open path.
+If \code{paths_only} is set to \code{TRUE} all rows where \code{path} is \code{NA} are
+removed.}
+}
+The returned \code{tidy_dagitty} object duplicates for each identified open path
+all node rows in the \code{data} element and labels for each identified open
+path (as indicated by column \code{set}) which nodes of the graph are on the
+path (as indicated by column \code{path}).
+}
+\item{\code{ggdag_paths}}{A \code{ggplot} object with a facet for each identified
+open path.}
+\item{\code{ggdag_paths_fan}}{A \code{ggplot} object with the same contents as
+with \code{ggdag_paths}, but identified open paths are plotted in one panel.}
+}
 }
 \description{
-\code{node_paths} finds the pathways between a given exposure and outcome.
-\code{ggdag_paths} plots all pathways. See \code{\link[dagitty:paths]{dagitty::paths()}} for details.
+\code{dag_paths} finds open paths between a given exposure and outcome.
+\code{ggdag_paths} and \code{ggdag_paths_fan} plot all open paths. See
+\code{\link[dagitty:paths]{dagitty::paths()}} for details.
 }
 \examples{
+confounder_triangle(x_y_associated = TRUE) \%>\%
+  dag_paths(from = "x", to = "y")
+
 confounder_triangle(x_y_associated = TRUE) \%>\%
   ggdag_paths(from = "x", to = "y")
 

--- a/man/paths.Rd
+++ b/man/paths.Rd
@@ -72,10 +72,9 @@ is \code{NULL}, in which case it will check the input DAG for exposure.}
 \item{adjust_for}{character vector, a set of variables to control for.
 Default is \code{NULL}.}
 
-\item{limit}{numeric value. The maximum number of paths to consider when
-identifying open paths. If \code{limit} is smaller than the number of paths
-between \code{from} and \code{to}, potential open pathways may not be returned.
-However, if \code{limit} is set too large, you may run into memory issues.}
+\item{limit}{maximum amount of paths to show. In general, the number of paths grows
+exponentially with the number of variables in the graph, such that path inspection
+is not useful except for the most simple models.}
 
 \item{directed}{logical. Should only directed paths be shown?}
 
@@ -111,28 +110,8 @@ Default is \code{NULL}.}
 \item{spread}{the width of the fan spread}
 }
 \value{
-\describe{
-\item{\code{dag_paths}}{A \code{tidy_dagitty} object with the following additional
-columns in the \code{data} element:
-\describe{
-\item{\code{set}}{A character vector representing an id for the identified
-open path.}
-\item{\code{path}}{A character vector with value \code{"open path"} if the
-corresponding node is on the identified open path and value \code{NA} if the
-corresponding node is not on the identified open path.
-If \code{paths_only} is set to \code{TRUE} all rows where \code{path} is \code{NA} are
-removed.}
-}
-The returned \code{tidy_dagitty} object duplicates for each identified open path
-all node rows in the \code{data} element and labels for each identified open
-path (as indicated by column \code{set}) which nodes of the graph are on the
-path (as indicated by column \code{path}).
-}
-\item{\code{ggdag_paths}}{A \code{ggplot} object with a facet for each identified
-open path.}
-\item{\code{ggdag_paths_fan}}{A \code{ggplot} object with the same contents as
-with \code{ggdag_paths}, but identified open paths are plotted in one panel.}
-}
+a \code{tidy_dagitty} with a \code{path} column for path variables and a \code{set}
+grouping column or a \code{ggplot}.
 }
 \description{
 \code{dag_paths} finds open paths between a given exposure and outcome.

--- a/man/repel.Rd
+++ b/man/repel.Rd
@@ -90,15 +90,13 @@ specified by passing \code{unit(x, "units")}).}
 to 1.}
 
 \item{max.iter}{Maximum number of iterations to try to resolve overlaps.
-Defaults to 10000.}
+Defaults to 2000.}
 
 \item{nudge_x}{Horizontal and vertical adjustments to nudge the
-starting position of each text label. The units for \code{nudge_x} and
-\code{nudge_y} are the same as for the data units on the x-axis and y-axis.}
+starting position of each text label.}
 
 \item{nudge_y}{Horizontal and vertical adjustments to nudge the
-starting position of each text label. The units for \code{nudge_x} and
-\code{nudge_y} are the same as for the data units on the x-axis and y-axis.}
+starting position of each text label.}
 
 \item{na.rm}{If \code{FALSE} (the default), removes missing values with
 a warning.  If \code{TRUE} silently removes missing values.}


### PR DESCRIPTION
Notes in addition to #65:
- I update `NEWS.md`.
- I had the feeling that the documentation was a bit confusing/too short. I tried to improve this (I hope this is okay).
- When building the package, there were additional changes in other Rd files. I assume these are changes in the documentation in R files I did not made which were just not transferred to the Rd files yet. I commited these, too.

Here's a reprex with the updated functions:

``` r
library(magrittr)
library(ggdag)
#> 
#> Attaching package: 'ggdag'
#> The following object is masked from 'package:stats':
#> 
#>     filter

# example
x_td <- 
  ggdag::dag("x1 -> x2
           x1 -> x3
           x2 -> x3
           x2 -> x4
           x3 -> x4
           x3 -> x5
           x4 -> x5
           x4 -> x6
           x4 -> x7
           x5 -> x7
           x5 -> x8
           x6 -> x8
           x1 -> x6
           x4 -> x9
           x2 -> x9
           x5 -> x9
           x9 -> x10
           x9 -> x3
           x10 -> x6
           x3 -> x10
           x5 -> x11") %>%
  ggdag::tidy_dagitty(seed = 345)

## updated version

# dag_paths
x_td_paths1 <- 
  dag_paths(x_td, from = "x5", to = "x8", limit = 200)

x_td_paths2 <- 
  dag_paths(x_td, from = "x5", to = "x8", limit = 100)

x_td_paths3 <- 
  dag_paths(x_td, from = "x5", to = "x8", limit = 10)

identical(x_td_paths1, x_td_paths2)
#> [1] FALSE
identical(x_td_paths1, x_td_paths3)
#> [1] FALSE
identical(x_td_paths2, x_td_paths3)
#> [1] FALSE

# ggdag_paths

ggdag_paths(x_td, from = "x5", to = "x8", limit = 200)
```

![](https://i.imgur.com/iIAr8tx.png)

``` r
ggdag_paths(x_td, from = "x5", to = "x8", limit = 100)
```

![](https://i.imgur.com/GcA5gAS.png)

``` r
ggdag_paths(x_td, from = "x5", to = "x8", limit = 10) # as expected since x_td_paths3 contains no nodes
#> Error: Problem with `filter()` input `..1`.
#> i Input `..1` is `path == "open path"`.
#> x object 'path' not found

# ggdag_paths_fan

ggdag_paths_fan(x_td, from = "x5", to = "x8", limit = 200)
```

![](https://i.imgur.com/M8pAHVs.png)

``` r
ggdag_paths_fan(x_td, from = "x5", to = "x8", limit = 100)
```

![](https://i.imgur.com/abPEgDk.png)

``` r
ggdag_paths_fan(x_td, from = "x5", to = "x8", limit = 10) # as expected since x_td_paths3 contains no nodes
#> Error: Problem with `filter()` input `..1`.
#> i Input `..1` is `path == "open path"`.
#> x object 'path' not found
```

<sup>Created on 2022-04-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">

<summary>Session info</summary>

``` r
sessioninfo::session_info()
#> - Session info ---------------------------------------------------------------
#>  setting  value                       
#>  version  R version 4.0.1 (2020-06-06)
#>  os       Windows 10 x64              
#>  system   i386, mingw32               
#>  ui       RTerm                       
#>  language (EN)                        
#>  collate  German_Germany.1252         
#>  ctype    German_Germany.1252         
#>  tz       Europe/Berlin               
#>  date     2022-04-07                  
#> 
#> - Packages -------------------------------------------------------------------
#>  package      * version    date       lib source        
#>  assertthat     0.2.1      2019-03-21 [1] CRAN (R 4.0.0)
#>  backports      1.1.7      2020-05-13 [1] CRAN (R 4.0.0)
#>  blob           1.2.1      2020-01-20 [1] CRAN (R 4.0.0)
#>  boot           1.3-25     2020-04-26 [2] CRAN (R 4.0.1)
#>  cli            3.1.0      2021-10-27 [1] CRAN (R 4.0.5)
#>  colorspace     1.4-1      2019-03-18 [1] CRAN (R 4.0.0)
#>  crayon         1.4.2      2021-10-29 [1] CRAN (R 4.0.5)
#>  curl           4.3.2      2021-06-23 [1] CRAN (R 4.0.5)
#>  dagitty        0.2-2      2016-08-26 [1] CRAN (R 4.0.0)
#>  DBI            1.1.0      2019-12-15 [1] CRAN (R 4.0.0)
#>  digest         0.6.25     2020-02-23 [1] CRAN (R 4.0.0)
#>  dplyr          1.0.7      2021-06-18 [1] CRAN (R 4.0.5)
#>  ellipsis       0.3.2      2021-04-29 [1] CRAN (R 4.0.5)
#>  evaluate       0.14       2019-05-28 [1] CRAN (R 4.0.0)
#>  fansi          0.4.1      2020-01-08 [1] CRAN (R 4.0.0)
#>  farver         2.0.3      2020-01-16 [1] CRAN (R 4.0.0)
#>  forcats        0.5.0      2020-03-01 [1] CRAN (R 4.0.0)
#>  fs             1.4.1      2020-04-04 [1] CRAN (R 4.0.0)
#>  generics       0.0.2      2018-11-29 [1] CRAN (R 4.0.0)
#>  ggdag        * 0.2.4.9000 2022-04-07 [1] local         
#>  ggforce        0.3.1      2019-08-20 [1] CRAN (R 4.0.0)
#>  ggplot2        3.3.2      2020-06-19 [1] CRAN (R 4.0.2)
#>  ggraph         2.0.3      2020-05-20 [1] CRAN (R 4.0.0)
#>  ggrepel        0.8.2      2020-03-08 [1] CRAN (R 4.0.0)
#>  glue           1.4.1      2020-05-13 [1] CRAN (R 4.0.2)
#>  graphlayouts   0.7.0      2020-04-25 [1] CRAN (R 4.0.0)
#>  gridExtra      2.3        2017-09-09 [1] CRAN (R 4.0.0)
#>  gtable         0.3.0      2019-03-25 [1] CRAN (R 4.0.0)
#>  highr          0.8        2019-03-20 [1] CRAN (R 4.0.0)
#>  htmltools      0.5.1.1    2021-01-22 [1] CRAN (R 4.0.3)
#>  httr           1.4.1      2019-08-05 [1] CRAN (R 4.0.0)
#>  igraph         1.2.5      2020-03-19 [1] CRAN (R 4.0.0)
#>  jsonlite       1.6.1      2020-02-02 [1] CRAN (R 4.0.1)
#>  knitr          1.37       2021-12-16 [1] CRAN (R 4.0.5)
#>  labeling       0.3        2014-08-23 [1] CRAN (R 4.0.0)
#>  lifecycle      1.0.1      2021-09-24 [1] CRAN (R 4.0.5)
#>  magrittr     * 1.5        2014-11-22 [1] CRAN (R 4.0.0)
#>  MASS           7.3-51.6   2020-04-26 [2] CRAN (R 4.0.1)
#>  mime           0.9        2020-02-04 [1] CRAN (R 4.0.0)
#>  munsell        0.5.0      2018-06-12 [1] CRAN (R 4.0.0)
#>  pillar         1.6.4      2021-10-18 [1] CRAN (R 4.0.5)
#>  pkgconfig      2.0.3      2019-09-22 [1] CRAN (R 4.0.0)
#>  polyclip       1.10-0     2019-03-14 [1] CRAN (R 4.0.0)
#>  purrr          0.3.4      2020-04-17 [1] CRAN (R 4.0.0)
#>  R6             2.4.1      2019-11-12 [1] CRAN (R 4.0.0)
#>  Rcpp           1.0.8      2022-01-13 [1] CRAN (R 4.0.5)
#>  reprex         2.0.1      2021-08-05 [1] CRAN (R 4.0.5)
#>  rlang          0.4.12     2021-10-18 [1] CRAN (R 4.0.5)
#>  rmarkdown      2.11       2021-09-14 [1] CRAN (R 4.0.5)
#>  rstudioapi     0.11       2020-02-07 [1] CRAN (R 4.0.0)
#>  scales         1.1.1      2020-05-11 [1] CRAN (R 4.0.0)
#>  sessioninfo    1.1.1      2018-11-05 [1] CRAN (R 4.0.0)
#>  stringi        1.4.6      2020-02-17 [1] CRAN (R 4.0.0)
#>  stringr        1.4.0      2019-02-10 [1] CRAN (R 4.0.0)
#>  styler         1.3.2      2020-02-23 [1] CRAN (R 4.0.2)
#>  tibble         3.1.6      2021-11-07 [1] CRAN (R 4.0.5)
#>  tidygraph      1.2.0      2020-05-12 [1] CRAN (R 4.0.0)
#>  tidyr          1.1.0      2020-05-20 [1] CRAN (R 4.0.0)
#>  tidyselect     1.1.0      2020-05-11 [1] CRAN (R 4.0.0)
#>  tweenr         1.0.1      2018-12-14 [1] CRAN (R 4.0.0)
#>  utf8           1.1.4      2018-05-24 [1] CRAN (R 4.0.0)
#>  V8             3.1.0      2020-05-29 [1] CRAN (R 4.0.0)
#>  vctrs          0.3.8      2021-04-29 [1] CRAN (R 4.0.5)
#>  viridis        0.5.1      2018-03-29 [1] CRAN (R 4.0.0)
#>  viridisLite    0.3.0      2018-02-01 [1] CRAN (R 4.0.0)
#>  withr          2.4.3      2021-11-30 [1] CRAN (R 4.0.5)
#>  xfun           0.29       2021-12-14 [1] CRAN (R 4.0.5)
#>  xml2           1.3.2      2020-04-23 [1] CRAN (R 4.0.0)
#>  yaml           2.2.1      2020-02-01 [1] CRAN (R 4.0.0)
#> 
#> [1] C:/Users/henni/Documents/R/win-library/4.0
#> [2] C:/Program Files/R/R-4.0.1/library
```

</details>
